### PR TITLE
Moved keys generation into model instead of shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,10 @@ install:
   - ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit $CAKE_DIR/vendors/PHPUnit
 
 before_script:
-  - if [ "$DB" = "pgsql" ]; then psql -c 'CREATE DATABASE lapis_default;' -U postgres; fi
   - if [ "$DB" = "pgsql" ]; then psql -c 'CREATE DATABASE lapis_test;' -U postgres; fi
-  - if [ "$DB" = "mysql" ]; then mysql -e 'CREATE DATABASE lapis_default;'; fi
   - if [ "$DB" = "mysql" ]; then mysql -e 'CREATE DATABASE lapis_test;'; fi
   - if [ "$DB" = "pgsql" ]; then echo "<?php
     class DATABASE_CONFIG {
-    public \$default = array(
-      'datasource' => 'Database/Postgres',
-      'database' => 'lapis_default',
-      'host' => '0.0.0.0',
-      'login' => 'travis',
-    );
     public \$test = array(
       'datasource' => 'Database/Postgres',
       'database' => 'lapis_test',
@@ -41,12 +33,6 @@ before_script:
     }" > $CAKE_DIR/app/Config/database.php; fi
   - if [ "$DB" = "mysql" ]; then echo "<?php
     class DATABASE_CONFIG {
-    public \$default = array(
-      'datasource' => 'Database/Mysql',
-      'database' => 'lapis_default',
-      'host' => '0.0.0.0',
-      'login' => 'travis',
-    );
     public \$test = array(
       'datasource' => 'Database/Mysql',
       'database' => 'lapis_test',
@@ -55,7 +41,6 @@ before_script:
     );
     }" > $CAKE_DIR/app/Config/database.php; fi
   - cd $CAKE_DIR/app; cat Config/database.php;
-  - Console/cake schema create --plugin Lapis --yes
 
 script:
   - cd $CAKE_DIR/app; Console/cake test Lapis AllTests --stderr

--- a/Console/Command/KeysShell.php
+++ b/Console/Command/KeysShell.php
@@ -12,22 +12,23 @@ class KeysShell extends AppShell {
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
 		$parser->addOption('yes', array(
-		  'short' => 'y',
-		  'help' => 'Do not prompt for confirmation. Be careful!',
-		  'boolean' => true
+			'short' => 'y',
+			'help' => 'Do not prompt for confirmation. Be careful!',
+			'boolean' => true
 		));
 		return $parser;
 	}
 
 	public function create() {
 		// TODO: options
-		// --size
+		// --keysize
 		// --root
 		// --parent_id
 		// --file
 		// --password
 
 		$options = array(
+			'size' => 4096,
 			'parentID' => null,
 			'savePrivateToDb' => true,
 			'privateKeyLocation' => null,
@@ -62,7 +63,7 @@ class KeysShell extends AppShell {
 		}
 
 		$this->out('Generating root public key pair...');
-		$keys = Lapis::genKeyPair();
+		$keys = Lapis::genKeyPair($options['keysize']);
 
 		$data = array(
 			'parent_id' => $options['parentID'],

--- a/Model/Key.php
+++ b/Model/Key.php
@@ -15,7 +15,7 @@ class Key extends AppModel {
 	public function generate($password, $options = array()) {
 		$options = array_merge(array(
 			'keysize' => 4096,
-			'parentID' => null,
+			'parent' => null,
 			'savePrivateToDb' => true,
 			'privateKeyLocation' => null
 		), $options);
@@ -24,7 +24,7 @@ class Key extends AppModel {
 		$keys = Lapis::genKeyPair($options['keysize']);
 
 		$data = array(
-			'parent_id' => $options['parentID'],
+			'parent_id' => $options['parent'],
 			'public_key' => $keys['public'],
 		);
 

--- a/Model/Key.php
+++ b/Model/Key.php
@@ -10,6 +10,46 @@ class Key extends AppModel {
 	public $name = 'Key';
 
 	/**
+	 * Generate RSA key pair
+	 */
+	public function generate($password, $options = array()) {
+		$options = array_merge(array(
+			'keysize' => 4096,
+			'parentID' => null,
+			'savePrivateToDb' => true,
+			'privateKeyLocation' => null
+		), $options);
+		$options['password'] = $password;
+
+		$keys = Lapis::genKeyPair($options['keysize']);
+
+		$data = array(
+			'parent_id' => $options['parentID'],
+			'public_key' => $keys['public'],
+		);
+
+		if ($options['savePrivateToDb']) {
+			if (!empty($options['password'])) {
+				$data['private_key'] = Lapis::pwEncrypt($keys['private'], $options['password']);
+			} else {
+				$data['private_key'] = $keys['private'];
+			}
+		}
+
+		$this->create();
+		$ok = $this->save($data);
+
+		if ($ok) {
+			if (!$options['savePrivateToDb']) {
+				return file_put_contents($options['privateKeyLocation'], $keys['private']);
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Return a list of ancestor IDs including self
 	 */
 	public function getAncestorIDs($ids, $includeSelf = true) {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _TODO: why Lapis_
 1. Generate the root key pair(s) by following the guided key generator. You would need at least 1 root key pair to use Lapis.
 
 	```bash
-	Console/cake Lapis.keys create    # follow the guided prompts
+	Console/cake Lapis.keys generate    # follow the guided prompts
 	```
 
 	It is highly recommended to not store private keys unencrypted at the database. If you provide a password to the private key, take note that the password is not stored anywhere in the system. You would have to store the password safely and separately outside of the system.

--- a/Test/Case/Model/KeyTest.php
+++ b/Test/Case/Model/KeyTest.php
@@ -23,7 +23,7 @@ class ExperienceTest extends CakeTestCase {
 
 		// No password
 		$this->assertTrue($this->Key->generate(null, array(
-			'parentID' => $id,
+			'parent' => $id,
 			'keysize' => 1024
 		)));
 		$secondID = $this->Key->getLastInsertID();

--- a/Test/Case/Model/KeyTest.php
+++ b/Test/Case/Model/KeyTest.php
@@ -1,0 +1,39 @@
+<?php
+class ExperienceTest extends CakeTestCase {
+
+	public $fixtures = array('plugin.lapis.key');
+
+	public function setUp() {
+		$this->Key = ClassRegistry::init('Lapis.Key');
+	}
+
+	public function testGenerate() {
+		$password = 'Passphrase to encrypt private key';
+		$this->assertTrue($this->Key->generate($password));
+		$id = $this->Key->getLastInsertID();
+		$this->assertEquals(1, $id);
+
+		$key = $this->Key->find('first', array(
+			'conditions' => array('Key.id' => $id)
+		));
+
+		$this->assertNull($key['Key']['parent_id']);
+		$this->assertContains('BEGIN PUBLIC KEY', $key['Key']['public_key']);
+		$this->assertNotContains('BEGIN PRIVATE KEY', $key['Key']['private_key']);
+
+		// No password
+		$this->assertTrue($this->Key->generate(null, array(
+			'parentID' => $id,
+			'keysize' => 1024
+		)));
+		$secondID = $this->Key->getLastInsertID();
+		$this->assertEquals(2, $secondID);
+
+		$key = $this->Key->find('first', array(
+			'conditions' => array('Key.id' => $secondID)
+		));
+		$this->assertEquals(1, $key['Key']['parent_id']);
+		$this->assertContains('BEGIN PUBLIC KEY', $key['Key']['public_key']);
+		$this->assertContains('BEGIN PRIVATE KEY', $key['Key']['private_key']);
+	}
+}

--- a/Test/Fixture/KeyFixture.php
+++ b/Test/Fixture/KeyFixture.php
@@ -1,4 +1,15 @@
 <?php
 class KeyFixture extends CakeTestFixture {
-	public $import = 'Lapis.Key';
+	public $table = 'lapis_keys';
+
+	/**
+	 * Load from schema.php (DRY)
+	 */
+	public function init() {
+		$schemaPath = dirname(dirname(dirname(__FILE__))) . DS . 'Config' . DS . 'Schema' . DS . 'schema.php';
+		$LapisSchema = require($schemaPath);
+		$schema = new LapisSchema;
+		$this->fields = $schema->tables[$this->table];
+		parent::init();
+	}
 }

--- a/Test/Fixture/KeyFixture.php
+++ b/Test/Fixture/KeyFixture.php
@@ -1,0 +1,20 @@
+<?php
+class KeyFixture extends CakeTestFixture {
+	public $import = 'Lapis.Key';
+	/*
+	public $fields = array(
+		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 11, 'key' => 'primary'),
+		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'parent_id' => array('type' => 'integer', 'null' => true, 'default' => null),
+		'parent_id' => array('type' => 'integer', 'null' => true, 'default' => null),
+		'public_key' => array('type' => 'text', 'null' => false),
+		'private_key' => array('type' => 'text', 'null' => true, 'default' => null),
+		'active' => array('type' => 'boolean', 'null' => false, 'default' => true),
+		'indexes' => array(
+			'PRIMARY' => array('unique' => true, 'column' => 'id')
+		),
+		'tableParameters' => array()
+	);
+	*/
+}


### PR DESCRIPTION
- Shell now calls model to generate and store keys.
- Updated test suite to support DB and added some simple test cases.
- Updated Travis.
